### PR TITLE
Improve and export errors in packages

### DIFF
--- a/lib/go/csvframer/CHANGELOG.md
+++ b/lib/go/csvframer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @grafana/infinity-csvframer
 
+## 1.0.1
+
+- improved error messages
+
 ## 1.0.0
 
 - chore release

--- a/lib/go/csvframer/errors.go
+++ b/lib/go/csvframer/errors.go
@@ -1,0 +1,8 @@
+package csvframer
+
+import "errors"
+
+var (
+	ErrEmptyCsv = errors.New("empty/invalid csv")
+	ErrReadingCsvResponse = errors.New("error reading csv response")
+)

--- a/lib/go/csvframer/framer.go
+++ b/lib/go/csvframer/framer.go
@@ -23,7 +23,7 @@ type FramerOptions struct {
 
 func ToFrame(csvString string, options FramerOptions) (frame *data.Frame, err error) {
 	if strings.TrimSpace(csvString) == "" {
-		return frame, errors.New("empty/invalid csv")
+		return frame, ErrEmptyCsv
 	}
 	r := csv.NewReader(strings.NewReader(csvString))
 	r.LazyQuotes = true
@@ -47,7 +47,7 @@ func ToFrame(csvString string, options FramerOptions) (frame *data.Frame, err er
 			continue
 		}
 		if !options.SkipLinesWithError {
-			return frame, fmt.Errorf("error reading csv response. %w, %v", err, record)
+			return frame, errors.Join(ErrReadingCsvResponse, fmt.Errorf("%w, %v", err, record))
 		}
 	}
 	out := []interface{}{}

--- a/lib/go/csvframer/framer_test.go
+++ b/lib/go/csvframer/framer_test.go
@@ -1,7 +1,6 @@
 package csvframer_test
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestCsvStringToFrame(t *testing.T) {
 	}{
 		{
 			name:      "empty csv should return error",
-			wantError: errors.New("empty/invalid csv"),
+			wantError: csvframer.ErrEmptyCsv,
 		},
 		{
 			name:      "valid csv should not return error",

--- a/lib/go/csvframer/package.json
+++ b/lib/go/csvframer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/infinity-csvframer",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "tidy": "go mod tidy",
     "test:backend": "go test -v  ./..."

--- a/lib/go/framesql/CHANGELOG.md
+++ b/lib/go/framesql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @grafana/infinity-framesql
 
+## 1.0.1
+
+- improved error messages
+
 ## 1.0.0
 
 - chore release

--- a/lib/go/framesql/errors.go
+++ b/lib/go/framesql/errors.go
@@ -1,0 +1,7 @@
+package framesql
+
+import "errors"
+
+var (
+	ErrEmptySummarizeExpression = errors.New("empty/invalid summarize expression")
+)

--- a/lib/go/framesql/frame.go
+++ b/lib/go/framesql/frame.go
@@ -2,7 +2,6 @@ package framesql
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -12,7 +11,7 @@ import (
 
 func EvaluateInFrame(expression string, input *data.Frame) (any, error) {
 	if strings.TrimSpace(expression) == "" {
-		return nil, errors.New(strings.TrimSpace(fmt.Sprintf("empty/invalid expression. %s", expression)))
+		return nil, ErrEmptySummarizeExpression
 	}
 	parsedExpression, err := govaluate.NewEvaluableExpressionWithFunctions(expression, expressionFunctions)
 	if err != nil {

--- a/lib/go/framesql/frame_test.go
+++ b/lib/go/framesql/frame_test.go
@@ -1,7 +1,6 @@
 package framesql_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -19,7 +18,7 @@ func TestEvaluateInFrame(t *testing.T) {
 		wantErr    error
 	}{
 		{
-			wantErr: errors.New("empty/invalid expression."),
+			wantErr: framesql.ErrEmptySummarizeExpression,
 		},
 		{
 			input:      data.NewFrame("test", data.NewField("sample", nil, []*float64{toFP(1), toFP(2), toFP(0.5), toFP(1.5)})),

--- a/lib/go/framesql/package.json
+++ b/lib/go/framesql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/infinity-framesql",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "tidy": "go mod tidy",
     "test:backend": "go test -v  ./..."

--- a/lib/go/transformations/CHANGELOG.md
+++ b/lib/go/transformations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @grafana/infinity-transformations
 
+## 1.0.1
+
+- improved error messages
+
 ## 1.0.0
 
 - chore release

--- a/lib/go/transformations/errors.go
+++ b/lib/go/transformations/errors.go
@@ -1,0 +1,14 @@
+package transformations
+
+import "errors"
+
+var (
+	ErrSummarizeByFieldNotFound = errors.New("summarize by field not found. Not applying summarize")
+	ErrNotUniqueFieldNames = errors.New("field names are not unique. Not applying filter")
+	ErrEvaluatingFilterExpression = errors.New("error evaluating filter expression")
+	
+	ErrMergeTransformationNoFrameSupplied = errors.New("no frames supplied for merge frame transformation")
+	ErrMergeTransformationDifferentFields = errors.New("unable to merge fields due to different fields")
+	ErrMergeTransformationDifferentFieldNames = errors.New("unable to merge field due to different field names")
+	ErrMergeTransformationDifferentFieldTypes = errors.New("unable to merge fields due to different field types")
+)

--- a/lib/go/transformations/filterExpression.go
+++ b/lib/go/transformations/filterExpression.go
@@ -42,7 +42,7 @@ func ApplyFilter(frame *data.Frame, filterExpression string) (*data.Frame, error
 	fieldKeys := map[string]bool{}
 	for _, field := range frame.Fields {
 		if fieldKeys[field.Name] {
-			return frame, errors.New("field names are not unique. Not applying filter")
+			return frame, ErrNotUniqueFieldNames
 		}
 		fieldKeys[field.Name] = true
 	}
@@ -57,7 +57,7 @@ func ApplyFilter(frame *data.Frame, filterExpression string) (*data.Frame, error
 		}
 		result, err := parsedExpression.Evaluate(parameters)
 		if err != nil {
-			return frame, fmt.Errorf("error evaluating filter expression for row %d. error: %w. Not applying filter", inRowIdx, err)
+			return frame, errors.Join(ErrEvaluatingFilterExpression,  fmt.Errorf("error: %w. row %d. Not applying filter", err, inRowIdx))
 		}
 		if currentMatch, ok := result.(bool); ok {
 			match = &currentMatch

--- a/lib/go/transformations/merge.go
+++ b/lib/go/transformations/merge.go
@@ -1,8 +1,6 @@
 package transformations
 
 import (
-	"errors"
-
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -17,7 +15,7 @@ type MergeFramesOptions struct {
 // Ref: https://github.com/grafana/grafana/blob/v9.5.2/packages/grafana-data/src/transformations/transformers/merge.ts
 func Merge(inputFrames []*data.Frame, option MergeFramesOptions) (*data.Frame, error) {
 	if len(inputFrames) < 1 {
-		return nil, errors.New("no frames supplied for merge frame transformation")
+		return nil, ErrMergeTransformationNoFrameSupplied
 	}
 	outFrame := inputFrames[0]
 	for frameId, frame := range inputFrames {
@@ -25,14 +23,14 @@ func Merge(inputFrames []*data.Frame, option MergeFramesOptions) (*data.Frame, e
 			continue
 		}
 		if len(outFrame.Fields) != len(frame.Fields) {
-			return nil, errors.New("unable to merge fields due to different fields")
+			return nil, ErrMergeTransformationDifferentFields
 		}
 		for fi, f := range frame.Fields {
 			if f.Name != outFrame.Fields[fi].Name {
-				return nil, errors.New("unable to merge field due to different field names")
+				return nil, ErrMergeTransformationDifferentFieldNames
 			}
 			if f.Type() != outFrame.Fields[fi].Type() {
-				return nil, errors.New("unable to merge fields due to different field types")
+				return nil, ErrMergeTransformationDifferentFieldTypes
 			}
 		}
 		for rowId := 0; rowId < frame.Rows(); rowId++ {

--- a/lib/go/transformations/package.json
+++ b/lib/go/transformations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/infinity-transformations",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "tidy": "go mod tidy",
     "test:backend": "go test -v  ./..."

--- a/lib/go/transformations/summarize.go
+++ b/lib/go/transformations/summarize.go
@@ -79,7 +79,7 @@ func GetSummarizeByFrame(frame *data.Frame, expression, by string, alias string)
 		}
 	}
 	if byField == nil {
-		return frame, errors.New("summarize by field not found. Not applying summarize")
+		return frame, ErrSummarizeByFieldNotFound
 	}
 	uniqueValuesArray := []any{}
 	uniqueValues := map[any]bool{}


### PR DESCRIPTION
This PR exports errors so we can check them in Infinity data source and add error source based on error type. This is same as what we did in https://github.com/grafana/infinity-libs/commit/c9bd79b3ed2330cc16dcdf818b05dbc42b8355c2