### PR TITLE
Improve and export errors in packages

### DIFF
--- a/lib/go/framesql/CHANGELOG.md
+++ b/lib/go/framesql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @grafana/infinity-framesql
 
+## 1.0.2
+
+- ⚙️ **Chore**: improved error messages
+
 ## 1.0.1
 
 - ⚙️ **Chore**: improved error messages

--- a/lib/go/framesql/errors.go
+++ b/lib/go/framesql/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrEmptySummarizeExpression = errors.New("empty/invalid summarize expression")
+	ErrExpressionNotFoundInFields = errors.New("expression not found in fields")
 )

--- a/lib/go/framesql/frame.go
+++ b/lib/go/framesql/frame.go
@@ -26,6 +26,11 @@ func EvaluateInFrame(expression string, input *data.Frame) (any, error) {
 		}
 	}
 	result, err := parsedExpression.Evaluate(parameters)
+	if err != nil {
+		if checkIfExpressionFoundInFields(err) {
+			return result, errors.Join(err, ErrExpressionNotFoundInFields)
+		}
+	}
 	return result, err
 }
 
@@ -205,4 +210,11 @@ func toFloat64p(input any) (*float64, bool) {
 		return &v1, true
 	}
 	return nil, false
+}
+
+func checkIfExpressionFoundInFields(err error) bool {
+	r := regexp.MustCompile(`No parameter '(.+)' found\.`)
+	// Check if the message matches the pattern
+  matches := r.FindStringSubmatch(err.Error())
+	return len(matches) > 0
 }

--- a/lib/go/framesql/package.json
+++ b/lib/go/framesql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/infinity-framesql",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "tidy": "go mod tidy",
     "test:backend": "go test -v  ./..."

--- a/lib/go/transformations/CHANGELOG.md
+++ b/lib/go/transformations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @grafana/infinity-transformations
 
+## 1.0.2
+
+- ⚙️ **Chore**: improved error messages
+
 ## 1.0.1
 
 - ⚙️ **Chore**: improved error messages

--- a/lib/go/transformations/errors.go
+++ b/lib/go/transformations/errors.go
@@ -6,6 +6,7 @@ var (
 	ErrSummarizeByFieldNotFound = errors.New("summarize by field not found. Not applying summarize")
 	ErrNotUniqueFieldNames = errors.New("field names are not unique. Not applying filter")
 	ErrEvaluatingFilterExpression = errors.New("error evaluating filter expression")
+	ErrInvalidToken = errors.New("invalid token")
 	
 	ErrMergeTransformationNoFrameSupplied = errors.New("no frames supplied for merge frame transformation")
 	ErrMergeTransformationDifferentFields = errors.New("unable to merge fields due to different fields")

--- a/lib/go/transformations/package.json
+++ b/lib/go/transformations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/infinity-transformations",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "tidy": "go mod tidy",
     "test:backend": "go test -v  ./..."


### PR DESCRIPTION
This PR exports errors so we can check them in Infinity data source and add error source based on error type. This is same as what we did in https://github.com/grafana/infinity-libs/commit/c9bd79b3ed2330cc16dcdf818b05dbc42b8355c2 and https://github.com/grafana/infinity-libs/pull/8.